### PR TITLE
fix: path修正

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -6,4 +6,5 @@ module.exports = defineConfig({
     host: '0.0.0.0', // 外部アクセスを許可
     port: 80, // ポート番号
   },
+  publicPath: '/VeriCook/' // リポジトリ名を指定
 })


### PR DESCRIPTION
この問題は、Vue CLI のプロジェクトがデフォルトでルート (`/`) を基準にリソースのパスを生成するために発生しています。GitHub Pages の場合、プロジェクトはリポジトリ名（例: `/VeriCook/`）を基準にする必要があります。

---

### 解決方法: vue.config.js に `publicPath` を設定

[`vue.config.js`](vue.config.js ) に `publicPath` を追加して、リソースの基準パスをリポジトリ名に設定します。

修正後の [`vue.config.js`](vue.config.js ):
```javascript
const { defineConfig } = require('@vue/cli-service')
module.exports = defineConfig({
  transpileDependencies: true,
  devServer: {
    watchFiles: ['src/**/*', 'public/**/*'], // ファイル変更を監視
    host: '0.0.0.0', // 外部アクセスを許可
    port: 80, // ポート番号
  },
  publicPath: process.env.NODE_ENV === 'production' ? '/VeriCook/' : '/', // リポジトリ名を指定
})
```

---

### `publicPath` の設定について
- **`process.env.NODE_ENV === 'production'`**:
  - 本番環境（`npm run build`）では `/VeriCook/` を基準にリソースを配置します。
  - 開発環境（`npm run serve`）では `/` を基準にリソースを配置します。

- **`/VeriCook/`**:
  - GitHub Pages のリポジトリ名に合わせて設定します（`https://<username>.github.io/<repository-name>/`）。

---

### 修正後の手順
1. [`vue.config.js`](vue.config.js ) を修正します。
2. 再度ビルドを実行します。
   ```bash
   npm run build
   ```
3. ビルドされたファイルを GitHub Pages にデプロイします。

---

### 注意点
- **リポジトリ名が変更された場合**:
  - `publicPath` の値もリポジトリ名に合わせて変更する必要があります。

- **カスタムドメインを使用する場合**:
  - カスタムドメインを使用する場合は、`publicPath` を `/` に設定します。

---

これで、GitHub Pages 上で正しいパスが使用されるようになります！